### PR TITLE
Link job run to target

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
@@ -2,6 +2,7 @@
 
 import type { Workspace } from "@ctrlplane/db/schema";
 import React, { Fragment, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { IconAlertTriangle, IconDots, IconLoader2 } from "@tabler/icons-react";
 import { capitalCase } from "change-case";
@@ -241,15 +242,13 @@ export const TargetReleaseTable: React.FC<TargetReleaseTableProps> = ({
                     idx !== jobs.length - 1 && "border-b-neutral-800/50",
                   )}
                 >
-                  <TableCell
-                    className="hover:bg-neutral-800/55"
-                    onClick={() => {
-                      router.push(
-                        `/${workspace.slug}/targets?target_id=${job.target?.id}`,
-                      );
-                    }}
-                  >
-                    {job.target?.name}
+                  <TableCell className="hover:bg-neutral-800/55">
+                    <Link
+                      href={`/${workspace.slug}/targets?target_id=${job.target?.id}`}
+                      className="block w-full hover:text-blue-300"
+                    >
+                      {job.target?.name}
+                    </Link>
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1">

--- a/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
@@ -208,7 +208,6 @@ export const TargetReleaseTable: React.FC<TargetReleaseTableProps> = ({
     release.id,
     { refetchInterval: 5_000 },
   );
-  const router = useRouter();
   if (releaseJobTriggerQuery.isLoading)
     return (
       <div className="flex h-full w-full items-center justify-center py-12">

--- a/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Workspace } from "@ctrlplane/db/schema";
 import React, { Fragment, useState } from "react";
 import { useRouter } from "next/navigation";
 import { IconAlertTriangle, IconDots, IconLoader2 } from "@tabler/icons-react";
@@ -34,8 +35,8 @@ import {
   TooltipTrigger,
 } from "@ctrlplane/ui/tooltip";
 
+import { JobTableStatusIcon } from "~/app/[workspaceSlug]/_components/JobTableStatusIcon";
 import { api } from "~/trpc/react";
-import { JobTableStatusIcon } from "../../../../../../_components/JobTableStatusIcon";
 
 const ForceReleaseTargetDialog: React.FC<{
   release: { id: string; version: string };
@@ -192,11 +193,13 @@ const TargetDropdownMenu: React.FC<{
 };
 
 type TargetReleaseTableProps = {
+  workspace: Workspace;
   release: { id: string; version: string };
   deploymentName: string;
 };
 
 export const TargetReleaseTable: React.FC<TargetReleaseTableProps> = ({
+  workspace,
   release,
   deploymentName,
 }) => {
@@ -204,7 +207,7 @@ export const TargetReleaseTable: React.FC<TargetReleaseTableProps> = ({
     release.id,
     { refetchInterval: 5_000 },
   );
-
+  const router = useRouter();
   if (releaseJobTriggerQuery.isLoading)
     return (
       <div className="flex h-full w-full items-center justify-center py-12">
@@ -238,7 +241,16 @@ export const TargetReleaseTable: React.FC<TargetReleaseTableProps> = ({
                     idx !== jobs.length - 1 && "border-b-neutral-800/50",
                   )}
                 >
-                  <TableCell>{job.target?.name}</TableCell>
+                  <TableCell
+                    className="hover:bg-neutral-800/55"
+                    onClick={() => {
+                      router.push(
+                        `/${workspace.slug}/targets?target_id=${job.target?.id}`,
+                      );
+                    }}
+                  >
+                    {job.target?.name}
+                  </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1">
                       <JobTableStatusIcon status={job.job.status} />

--- a/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/page.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/page.tsx
@@ -27,6 +27,8 @@ export default async function ReleasePage({
 }) {
   const release = await api.release.byId(params.versionId);
   const deployment = await api.deployment.bySlug(params);
+  const workspace = await api.workspace.bySlug(params.workspaceSlug);
+  if (workspace == null) return notFound();
 
   if (release == null || deployment == null) notFound();
 
@@ -86,6 +88,7 @@ export default async function ReleasePage({
         </div>
 
         <TargetReleaseTable
+          workspace={workspace}
           release={release}
           deploymentName={deployment.name}
         />


### PR DESCRIPTION
Link to target when you click on any of the left most column cells in the table.

There is a slight indication that it does something on hover, but not super apparent like underlining the text.

Not sure if we want the cell clickable or just the words in the cell so we don't break people trying to copy text. 
I recommend against making the whole row clickable. 